### PR TITLE
Send Package Version and Get back separated Params

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,5 +18,7 @@ module.exports = {
     'react/jsx-props-no-spreading': 'off',
     'linebreak-style': 'off',
     'react/default-props-match-prop-types': 'off',
+    'import/prefer-default-export': 'off',
+    '@typescript-eslint/quotes': 'off',
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stardust-platform/web-login",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Stardust auth library in Typescript!",
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   "license": "GPL-3.0-only",
   "scripts": {
     "start": "watch \"yarn build\" ./src",
+    "prebuild": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "build": "yarn build:esm && yarn build:cjs",
     "build:esm": "tsc",
     "build:cjs": "tsc --module commonjs --outDir lib/cjs",

--- a/src/components/Provider/index.tsx
+++ b/src/components/Provider/index.tsx
@@ -77,6 +77,13 @@ export const AuthProvider: FC<ProviderProps> = function (props) {
     const email = params.get('email');
     if (!email && challenge) {
       const [Email, Challenge] = challenge.split(',');
+      if (typeof Challenge === 'undefined') {
+        return setSnackBarStatus({
+          isOpen: true,
+          hasError: true,
+          message: 'Challenge response cannot be empty, value after email in link',
+        });
+      }
       finishSignin(Email, Challenge);
     } else if (email && challenge) {
       finishSignin(email, challenge);

--- a/src/components/Provider/index.tsx
+++ b/src/components/Provider/index.tsx
@@ -49,9 +49,8 @@ export const AuthProvider: FC<ProviderProps> = function (props) {
     dispatch,
   }), [state]);
 
-  const finishSignin = async (challenge: any) => {
+  const finishSignin = async (email: string, code: string) => {
     try {
-      const [email, code] = challenge.split(',');
       // MUST be here for TriggerPlayerPreTokenGeneration
       Auth.configure({ clientMetadata: { 'custom:gameId': process.env.REACT_APP_GAME_ID } });
       const user = await Auth.signIn(email);
@@ -75,8 +74,13 @@ export const AuthProvider: FC<ProviderProps> = function (props) {
   useEffect(() => {
     const params = new URLSearchParams(window?.location?.search);
     const challenge = params.get('challenge');
+    const email = params.get('email');
+    const code = params.get('code');
     if (challenge) {
-      finishSignin(challenge);
+      const [Email, Code] = challenge.split(',');
+      finishSignin(Email, Code);
+    } else if (email && code) {
+      finishSignin(email, code);
     }
     if (state.isResendClicked) {
       setTimeout(() => {
@@ -153,8 +157,8 @@ export const AuthProvider: FC<ProviderProps> = function (props) {
 
   useEffect(() => {
     (async () => {
-      const params = window.location.search;
-      if (params.startsWith('?challenge=')) {
+      const params = new URLSearchParams(window?.location?.search);
+      if (params.get('challenge') || (params.get('email') && params.get('code'))) {
         return dispatch({ type: Types.handleSessionLoading, payload: true });
       }
       const user = await checkUserLoggedIn(dispatch);

--- a/src/hooks/useEmailSignin.ts
+++ b/src/hooks/useEmailSignin.ts
@@ -1,6 +1,7 @@
 // libs
 import axios from 'axios';
 import { Auth } from 'aws-amplify';
+import { LIB_VERSION } from '../version';
 
 // Interfaces
 import { EmailError } from '../screens/Signin/types';
@@ -34,7 +35,9 @@ const useEmailSignin = (
   const loginWithMagicLink = async () => {
     try {
       await axios.post(loginUrl, {
-        email, redirect: magicLinkRedirectUrl ?? window?.location?.origin,
+        email,
+        redirect: magicLinkRedirectUrl ?? window?.location?.origin,
+        version: LIB_VERSION,
       });
       cleanErrors();
       setIsEmailLoading(true);

--- a/src/screens/Signin/index.tsx
+++ b/src/screens/Signin/index.tsx
@@ -33,6 +33,7 @@ import {
 import { EmailError, SigninProps } from './types';
 // eslint-disable-next-line import/no-cycle
 import { Types } from '../../components/Provider/types';
+import { LIB_VERSION } from '../../version';
 
 // eslint-disable-next-line func-names
 const Signin: FC<SigninProps> = function ({ closeModal, custom, authContext }) {
@@ -168,6 +169,10 @@ const Signin: FC<SigninProps> = function ({ closeModal, custom, authContext }) {
                   <SeparatorLine />
 
                   <TermsText>
+                    Version: {LIB_VERSION}
+                    <br />
+                    <br />
+                    {' '}
                     When you sign up, you’re accepting our
                     <br />
                     {' '}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const LIB_VERSION = "1.0.12";


### PR DESCRIPTION
- URL endpoint emails recipient a CSV format params.
- The request was to give back separated params (email, challenge) instead of (challenge).
- Prepare to next Version.

# Changes Stardust Auth:

## Description
Send to server a version of the package and get back from server separated params URL.

## Type of change
Mark all types that apply and delete options that are not relevant.
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Checked requests after server update with the old package and the new package versions.
I was able to get both CSV and Separated params depending on the version of the package.

## Checklist:
- [ x ] My code follows the style guidelines of this project ([airbnb](https://github.com/airbnb/javascript))
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ ] Looks good on large screens
- [ ] Looks good on mobile
