### PR TITLE
STARPLAT-1398 Adding oauth overwrite from awsExports argument

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,6 +43,7 @@ const overwriteEnvironment = (awsExports: any, loginUrl: string) => {
     ...awsExports,
     Auth: { oauth: { responseType: 'code' } },
     oauth: {
+      ...awsconfig.oauth,
       ...awsExports.oauth,
       responseType: 'code',
       redirectSignIn: origin,


### PR DESCRIPTION
In the overwriteEnvironment method, oauth settings weren't referencing the custom config. This prevented a consumer from providing a custom auth domain for the oauth flow.

# Changes Stardust Auth:

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related to: [STARPLAT-1398](https://stardustgg.atlassian.net/browse/STARPLAT-1398) Web-login google login not working on dev

## Screenshots
<img width="408" alt="image" src="https://user-images.githubusercontent.com/337856/168703031-34764e31-274f-4219-bbbf-420305af0bcf.png">


## Type of change
Mark all types that apply and delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- Step 1: Entered broken config values for the base aws-exports.ts file and ensured the app was broken as a result
- Step 2: Used overwriteEnvironment to overwrite the broken values with the original base config and ensured the app worked again

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Looks good on large screens
- [ ] Looks good on mobile
